### PR TITLE
Fix Github pages action

### DIFF
--- a/.github/workflows/push-updates.yml
+++ b/.github/workflows/push-updates.yml
@@ -13,15 +13,17 @@ jobs:
       - uses: actions/checkout@v2
         with: 
           repository: security-summer-school/security-summer-school.github.io
+          token: ${{ secrets.ESSENTIALS_PRIVATE_TOKEN }}
 
       - name: Pull and update submodule recursively
         run: |
-          git submodule update --remote --recursive --merge
+          git submodule update --init --recursive
+          git submodule update --remote --recursive -- content/en/essentials/
 
       - name: Commit
         run: |
           git config user.email "essentials-updater@github.com"
           git config user.name "Essentials Track Updater"
-          git add --all
+          git add content/en/essentials/
           git commit -m "essentials: Update track submodule" || echo "No changes to commit"
           git push


### PR DESCRIPTION
The action for pushing updates to https://github.com/security-summer-school/security-summer-school.github.io was failing because neither repo contained `secrets.ESSENTIALS_PRIVATE_TOKEN`. This PR fixes this issue by using the aforementioned `secret`.